### PR TITLE
Add package.json and basic test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # pierwszy-kod
-Test dla Codex
+
+Simple web app demonstrating a welcome message.
+
+Open `index.html` in your browser to see it in action.
+
+## Development
+
+Install dependencies (none are needed) and run tests with npm:
+
+```bash
+npm test
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome App</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="message"></div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pierwszy-kod",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test.js"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,4 @@
+document.addEventListener('DOMContentLoaded', function() {
+    var message = document.getElementById('message');
+    message.textContent = 'Welcome to our web app!';
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,13 @@
+body {
+    font-family: Arial, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+#message {
+    font-size: 2em;
+    color: #333;
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+try {
+  const html = fs.readFileSync('index.html', 'utf8');
+  if (html.includes('id="message"')) {
+    console.log('Test passed.');
+    process.exit(0);
+  } else {
+    console.error('Test failed: message element missing.');
+    process.exit(1);
+  }
+} catch (err) {
+  console.error('Test failed:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `package.json` so `npm test` is defined
- add a simple `test.js` checking that `index.html` contains the message element
- document running tests in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68447fe2c0608331b282669d4bd4b501